### PR TITLE
Fixes for Schema Version 2 - page.hint.locations and Story.id

### DIFF
--- a/schema/story.schema.02.json
+++ b/schema/story.schema.02.json
@@ -184,9 +184,9 @@
           "uniqueItems": true
         }
       },
-      "requiredProperties": [
+      "required": [
         "direction",
-        "location"
+        "locations"
       ],
       "additionalProperties": false
     },

--- a/schema/story.schema.02.json
+++ b/schema/story.schema.02.json
@@ -4,10 +4,6 @@
   "description": "This schema defines how a story is stored ",
   "type": "object",
   "properties": {
-    "id": {
-      "description": "The unique identifier for the story",
-      "type": "string"
-    },
     "name": {
       "description": "The title of the story",
       "type": "string"
@@ -95,7 +91,6 @@
   },
   "additionalProperties": false,
   "required": [
-    "id",
     "name",
     "author",
     "pages",

--- a/src/File.ts
+++ b/src/File.ts
@@ -44,7 +44,7 @@ export class File {
     static fileExistsAndIsReadable(fileName) {
 
         try {
-            fs.accessSync(fileName, fs.R_OK);
+            fs.accessSync(fileName, fs.constants.R_OK);
         } catch (e) {
             return false;
         }

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -49,12 +49,18 @@ import {core} from "./schemaUpgraders/core";
 
 let filename = processCommandLine();
 
+console.error("Beginning program...");
+
 getFile(filename)
     .then(contents => {
-        let data = JSON.parse(contents);
-        let result = new core().upgradeSchema(data, true);
+        if(typeof contents === "string") {
+          let data = JSON.parse(contents);
+          let validate = true;
+          let result = new core().upgradeSchema(data, validate);
 
-        outputResult(result);
+          outputResult(result);
+        }
+        console.error("Error given invalid data - Should totally fix in Typescript");
 
     }, error => {
         console.error(error);
@@ -67,7 +73,7 @@ getFile(filename)
 /* End of code */
 
 function outputResult(result) {
-    let contents = JSON.stringify(result);
+    let contents = JSON.stringify(result, null, 2);
 
     if (program.outfile) {
         File.createFile(program.outfile, contents);

--- a/src/schemaUpgraders/core.ts
+++ b/src/schemaUpgraders/core.ts
@@ -23,7 +23,10 @@ export class core {
         let currentVersionIndex = this.detectSchemaVersionIndex(data);
         let startingVersionIndex = currentVersionIndex + 1;
 
+        console.log("Current schema version: ", currentVersionIndex);
+
         for (let newVersionIndex = startingVersionIndex; newVersionIndex <= lastVersionIndex; newVersionIndex++) {
+            console.log("Upgrading to schema version: ", newVersionIndex);
             data = this.upgradeToSchemaIndex(newVersionIndex, data, validate);
         }
 
@@ -35,7 +38,9 @@ export class core {
         newSchema.schemaVersion = this.schemas[newVersionIndex].schema;
 
         if (validate) {
-            this.validateSchema(newSchema, path.resolve(__dirname, "..", "..", "schema", this.schemas[newVersionIndex].schemaFile));
+            console.log("Performing Schema Validation");
+            let result = this.validateSchema(newSchema, path.resolve(__dirname, "..", "..", "schema", this.schemas[newVersionIndex].schemaFile));
+            console.log(result? "Schema successfully validated" : "Invalid schema");
         }
 
         return newSchema;
@@ -54,6 +59,7 @@ export class core {
             throw ajv.errorsText();
         }
 
+        return true;
     }
 
     private detectSchemaVersionIndex(data) {

--- a/src/schemaUpgraders/draft-02.ts
+++ b/src/schemaUpgraders/draft-02.ts
@@ -59,7 +59,7 @@ export class v2 {
         this.changeTimeConditionVariableNames();
         this.convertCachedMediaIdToStrings();
         this.fixMissingPageId();
-        this.fixMissingStoryId();
+        this.removeStoryId();
 
         return this.data;
     }
@@ -456,10 +456,7 @@ export class v2 {
         });
     }
 
-    private fixMissingStoryId() {
-        if (this.data.id === undefined) {
-            this.data.id = this.data.name.replace(/[^A-Za-z0-9]/g, '');
-            console.log("Story ID generated:", this.data.id);
-        }
+    private removeStoryId() {
+        delete this.data.id;
     }
 }

--- a/src/schemaUpgraders/draft-02.ts
+++ b/src/schemaUpgraders/draft-02.ts
@@ -59,6 +59,7 @@ export class v2 {
         this.changeTimeConditionVariableNames();
         this.convertCachedMediaIdToStrings();
         this.fixMissingPageId();
+        this.fixMissingStoryId();
 
         return this.data;
     }
@@ -446,11 +447,19 @@ export class v2 {
     }
 
     private fixMissingPageId() {
-        this.data.pages.map(page => {
+        this.data.pages = this.data.pages.map(page => {
             if (page.id === undefined) {
                 page.id = page.name.replace(/[^A-Za-z0-9]/g, '');
-                console.log(page.id);
+                console.log("Page ID generated:", page.id);
             }
+            return page;
         });
+    }
+
+    private fixMissingStoryId() {
+        if (this.data.id === undefined) {
+            this.data.id = this.data.name.replace(/[^A-Za-z0-9]/g, '');
+            console.log("Story ID generated:", this.data.id);
+        }
     }
 }


### PR DESCRIPTION
page.hint.locations in V2 schema wasn't marked as required, meaning some stories could validate with the schema, but be erroneous. This caused a Javascript error preventing pages being clicked on on the client.